### PR TITLE
[EasySecurity] Fixed RegisterPermissionExpressionFunctionPass not accepting target permissions.

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterPermissionExpressionFunctionPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterPermissionExpressionFunctionPass.php
@@ -23,6 +23,7 @@ final class RegisterPermissionExpressionFunctionPass implements CompilerPassInte
 
         $providerClass = PermissionExpressionFunctionProvider::class;
         $providerDef = new Definition($providerClass);
+        $providerDef->setArgument('$target', $locations);
 
         $container->setDefinition($providerClass, $providerDef);
 


### PR DESCRIPTION
- Fixed error for RegisterPermissionExpressionFunctionPass to set targets for PermissionExpressionFunctionProvider.